### PR TITLE
Bugfix selected folders being navigated to

### DIFF
--- a/Scripts/ExplorerDialogPathSelector.ahk
+++ b/Scripts/ExplorerDialogPathSelector.ahk
@@ -581,6 +581,22 @@ PathSelector_Navigate(ThisMenuItemName, ThisMenuItemPos, MyMenu, f_path, windowC
         if (dialogInfo.Type = "HasEditControl") {
             ; Send the path to the edit control text box using SendMessage
             DllCall("SendMessage", "Ptr", dialogInfo.ControlHwnd, "UInt", 0x000C, "Ptr", 0, "Str", path) ; 0xC is WM_SETTEXT - Sets the text of the text box
+
+            ; Set focus to the text box (this will make it active and ready for input)
+            DllCall("SendMessage", "Ptr", dialogInfo.ControlHwnd, "UInt", 0x0007, "Ptr", 0, "Ptr", 0) ; 0x7 is WM_SETFOCUS
+
+            ; Simulate pressing the Right Arrow key
+            DllCall("SendMessage", "Ptr", dialogInfo.ControlHwnd, "UInt", 0x0100, "UInt", 0x27, "Ptr", 0) ; WM_KEYDOWN with Right Arrow key (0x27)
+            DllCall("SendMessage", "Ptr", dialogInfo.ControlHwnd, "UInt", 0x0101, "UInt", 0x27, "Ptr", 0) ; WM_KEYUP with Right Arrow key (0x27)
+
+            if (SubStr(path, -1) = "\") {
+                ; Simulate pressing the Backspace key to remove the trailing backslash
+                DllCall("SendMessage", "Ptr", dialogInfo.ControlHwnd, "UInt", 0x0102, "UInt", 0x08, "Ptr", 0) ; WM_CHAR with Backspace key (0x08)
+            }
+
+            ; Simulate pressing the Backslash key to focus the text box
+            DllCall("SendMessage", "Ptr", dialogInfo.ControlHwnd, "UInt", 0x0102, "UInt", 0x5C, "Ptr", 0) ; WM_CHAR with Backslash key (0x5C)
+
             ; Tell the dialog to accept the text box contents, which will cause it to navigate to the path
             DllCall("SendMessage", "Ptr", windowHwnd, "UInt", 0x0111, "Ptr", 0x1, "Ptr", 0) ; command ID (0x1) typically corresponds to the IDOK control which represents the primary action button, whether it's labeled "Save" or "Open".
 

--- a/Scripts/ExplorerDialogPathSelector.ahk
+++ b/Scripts/ExplorerDialogPathSelector.ahk
@@ -579,6 +579,11 @@ PathSelector_Navigate(ThisMenuItemName, ThisMenuItemPos, MyMenu, f_path, windowC
     ; ------------------------- LOCAL FUNCTIONS -------------------------
     NavigateDialog(path, windowHwnd, dialogInfo) {
         if (dialogInfo.Type = "HasEditControl") {
+            ; Remove trailing backslash
+            if (SubStr(path, -1) = "\") {
+                path := SubStr(path, 1, -1)
+            }
+
             ; Send the path to the edit control text box using SendMessage
             DllCall("SendMessage", "Ptr", dialogInfo.ControlHwnd, "UInt", 0x000C, "Ptr", 0, "Str", path) ; 0xC is WM_SETTEXT - Sets the text of the text box
 
@@ -588,11 +593,6 @@ PathSelector_Navigate(ThisMenuItemName, ThisMenuItemPos, MyMenu, f_path, windowC
             ; Simulate pressing the Right Arrow key
             DllCall("SendMessage", "Ptr", dialogInfo.ControlHwnd, "UInt", 0x0100, "UInt", 0x27, "Ptr", 0) ; WM_KEYDOWN with Right Arrow key (0x27)
             DllCall("SendMessage", "Ptr", dialogInfo.ControlHwnd, "UInt", 0x0101, "UInt", 0x27, "Ptr", 0) ; WM_KEYUP with Right Arrow key (0x27)
-
-            if (SubStr(path, -1) = "\") {
-                ; Simulate pressing the Backspace key to remove the trailing backslash
-                DllCall("SendMessage", "Ptr", dialogInfo.ControlHwnd, "UInt", 0x0102, "UInt", 0x08, "Ptr", 0) ; WM_CHAR with Backspace key (0x08)
-            }
 
             ; Simulate pressing the Backslash key to focus the text box
             DllCall("SendMessage", "Ptr", dialogInfo.ControlHwnd, "UInt", 0x0102, "UInt", 0x5C, "Ptr", 0) ; WM_CHAR with Backslash key (0x5C)


### PR DESCRIPTION
If an item is selected in the Save As popup, the Enter keypress doesn't get focused on the input box.
![image](https://github.com/user-attachments/assets/d38c9d47-41c4-40ac-ab08-26ba447ba737)

Even if the file is then deselected, as long as something in the file selection pane was clicked, it will still be focused.
![image](https://github.com/user-attachments/assets/ae376829-381f-459c-b549-10e69025e570)
![image](https://github.com/user-attachments/assets/46343422-9ace-4c54-96cd-591404ae4e79)

This will also navigate to folders rather than the pasted in path if they were highlighted.

---

My fix is to select the text field, press the right arrow key to move the cursor to the end, and type a backslash (if the path already ends in a backslash, it'll send Backspace first - I tested this, it works). This will focus the text field and show the folder popup, allowing pressing Enter to navigate correctly.
![image](https://github.com/user-attachments/assets/e74f6f63-db45-4b88-9b42-76e9b2a26a71)

I'm not sure if this fixes the non-legacy dialog, or if this is even an issue there. But this is what fixed it for me, so I figured I'd at least make a PR.